### PR TITLE
Updating the version number for wp 6.3

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,5 +1,10 @@
 # Change log
 
+## [[1.2.7]](https://github.com/lightspeeddevelopment/lsx-currencies/releases/tag/1.2.7) - 2023-08-09
+
+### Security
+-   General testing to ensure compatibility with latest WordPress version (6.3).
+
 ## [[1.2.6]](https://github.com/lightspeeddevelopment/lsx-currencies/releases/tag/1.2.6) - 2023-04-20
 
 ### Fixed 

--- a/lsx-currencies.php
+++ b/lsx-currencies.php
@@ -3,7 +3,7 @@
  * Plugin Name: LSX Currencies
  * Plugin URI:  https://www.lsdev.biz/product/lsx-currencies
  * Description: The LSX Currencies extension adds currency selection functionality to sites, allowing users to view your products in whatever currencies you choose to sell in.
- * Version:     1.2.6
+ * Version:     1.2.7
  * Author:      LightSpeed
  * Author URI:  https://www.lsdev.biz/
  * License:     GPL3
@@ -20,7 +20,7 @@ if ( ! defined( 'WPINC' ) ) {
 define( 'LSX_CURRENCIES_PATH', plugin_dir_path( __FILE__ ) );
 define( 'LSX_CURRENCIES_CORE', __FILE__ );
 define( 'LSX_CURRENCIES_URL', plugin_dir_url( __FILE__ ) );
-define( 'LSX_CURRENCIES_VER', '1.2.6' );
+define( 'LSX_CURRENCIES_VER', '1.2.7' );
 
 require_once LSX_CURRENCIES_PATH . 'classes/deprecated/class-lsx-currencies.php';
 require_once LSX_CURRENCIES_PATH . 'classes/class-currencies.php';

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "lsx-currencies",
-  "version": "1.2.6",
+  "version": "1.2.7",
   "description": "Currencies for LSX",
   "main": "gulpfile.js",
   "scripts": {

--- a/readme.txt
+++ b/readme.txt
@@ -3,9 +3,9 @@ Contributors: feedmymedia, lightspeedwp, eleshar, krugazul, jacquesvdh, ignusver
 Donate link: https://lsdev.biz/lsx/donate/
 Tags: lsx, gutenberg, currency switcher, currencies, currency converter
 Requires at least: 5.0
-Tested up to: 6.2
-Requires PHP: 7.2
-Stable tag: 1.2.6
+Tested up to: 6.3
+Requires PHP: 7.4
+Stable tag: 1.2.7
 License: GPLv3 or later
 License URI: https://www.gnu.org/licenses/gpl-3.0.en.html
 


### PR DESCRIPTION
### Description
- General testing to ensure compatibility with latest WordPress version (6.3).
- Updating the version number and stable tag